### PR TITLE
Don't allow sanitize in BS popover

### DIFF
--- a/src/coffee/bootstrap-tour.coffee
+++ b/src/coffee/bootstrap-tour.coffee
@@ -509,6 +509,7 @@
         title: step.title
         content: step.content
         html: true
+        sanitize: false
         animation: step.animation
         container: step.container
         template: step.template


### PR DESCRIPTION
In [BS v3.4.1](https://github.com/twbs/bootstrap/blob/v3.4.1/js/popover.js#L51) tooltips and popovers sanitize HTML by default, thus removing navigation buttons from the tour.